### PR TITLE
Remove 'Mods disabled' message

### DIFF
--- a/src/electron/index.html
+++ b/src/electron/index.html
@@ -63,9 +63,6 @@
           <img class="flat-icon" src="resources/interrogation.svg" height="16" width="16" />
         </a>
       </div>
-      <div id="modder">
-        Mods disabled. Enable it below to see effects in-game.
-      </div>
       <b>NOTE:</b> Use this feature at your own risk.
       <br>
       <label title="Whether or not the proxy should process mods.">


### PR DESCRIPTION
Someone pointed out that it looked like an error message even though a lot of people may not use mods, so I suggest removing it altogether